### PR TITLE
docs: add required project documentation per Codexium standards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# ============================================================
+# Mi Colombia Digital -- Environment Variables
+# ============================================================
+# Copy this file to .env.local and fill in the values:
+#   cp .env.example .env.local
+#
+# The app runs in mock mode by default. Supabase credentials
+# are only required for real data integration.
+# ============================================================
+
+# --- Supabase Configuration ---
+# Required for production. Leave empty to use mock data mode.
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+
+# Service role key -- server-side only, NEVER expose to client.
+# Required for admin operations and database migrations.
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# --- App Configuration ---
+# Default country code for the platform (CO, EC, GT)
+NEXT_PUBLIC_DEFAULT_COUNTRY=CO
+
+# Public URL of the application
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# --- Feature Flags ---
+# Enable mock data mode (set to false for production with real Supabase)
+NEXT_PUBLIC_ENABLE_MOCK_DATA=true
+
+# Enable offline/PWA mode (service worker caching)
+NEXT_PUBLIC_ENABLE_OFFLINE_MODE=true
+
+# Enable biometric authentication (WebAuthn)
+NEXT_PUBLIC_ENABLE_BIOMETRIC_AUTH=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md -- Mi Colombia Digital
+
+## Project
+
+**Name:** Mi Colombia Digital (colombia-digital-wallet)
+**Type:** Citizen Digital Wallet -- Progressive Web App (PWA)
+**Description:** Centralizes Colombian government documents and services into a single mobile-first web application. White-label, multi-country framework supporting Colombia, Ecuador, and Guatemala.
+
+## Tech Stack
+
+- **Framework:** Next.js 14 (App Router)
+- **Language:** TypeScript (strict mode)
+- **Styling:** TailwindCSS 3 with dark mode (`class` strategy)
+- **State Management:** Zustand (global state), TanStack React Query (server state)
+- **Backend:** Supabase (PostgreSQL, Auth, Storage, Real-time)
+- **Validation:** Zod (with Spanish error messages for citizen forms)
+- **PWA:** next-pwa (offline support, installable)
+- **QR Codes:** react-qr-code
+- **Icons:** Lucide React
+- **Testing:** Playwright (E2E, 3 browser projects)
+- **CI/CD:** GitHub Actions
+- **Deployment:** Vercel (recommended)
+
+## Project Structure
+
+```
+src/
+  app/
+    (auth)/           # Login, register, verify pages
+    (citizen)/        # Citizen-facing app (Spanish UI)
+    (admin)/          # Government admin dashboard
+    (agency)/         # Agency staff portal (multi-country)
+    api/              # API routes (planned, not yet implemented)
+  components/
+    ui/               # Reusable components (Button, Card, Input, Modal, etc.)
+    documents/        # Document cards (DocumentCard, VehicleCard, HealthCard)
+    cards/            # Dashboard cards (StatCard, QuickActionCard)
+    layout/           # Navigation (Header, BottomNav, Sidebar, AgencySidebar)
+    admin/            # Admin-specific components
+    auth/             # Auth form components
+  config/
+    countries/        # Country JSON configs (colombia.json, ecuador.json, guatemala.json)
+    index.ts          # Config loader
+  lib/
+    supabase/         # Supabase clients (client.ts, server.ts, middleware.ts)
+    contexts/         # React contexts (AuthContext, CountryContext, AdminRoleContext)
+    hooks/            # Custom hooks (useAuth)
+    providers/        # QueryProvider (TanStack React Query)
+    types/            # TypeScript types (database.ts)
+    mock/             # Mock data (citizenData, adminData, agencyData, ticketData)
+    validations/      # Zod schemas (auth, citizen, admin)
+    utils/            # Utilities (cn.ts, logger.ts, csrf.ts)
+    middleware/       # Rate limiter (rateLimit.ts)
+  middleware.ts       # Root middleware (route protection, auth redirects)
+supabase/
+  migrations/         # SQL migrations (001_initial_schema, 002_rls_policies)
+tests/
+  e2e/                # Playwright tests organized by feature area
+    auth/             # Authentication tests
+    citizen/          # Citizen app tests
+    admin/            # Admin dashboard tests
+    agency/           # Agency portal tests
+    config/           # Multi-country switching tests
+docs/
+  en/                 # English documentation (ONBOARDING, ARCHITECTURE, API_REFERENCE, TESTING)
+  es/                 # Spanish documentation (same structure)
+  PRODUCTION_ROADMAP.md
+  TODO_QUEUE.md
+```
+
+## Setup
+
+```bash
+npm install
+cp .env.local.example .env.local   # Configure environment variables
+npm run dev                        # Start dev server at http://localhost:3000
+npx playwright install             # Install test browsers (first time)
+```
+
+The app runs in mock mode by default -- no Supabase connection required. Set `NEXT_PUBLIC_ENABLE_MOCK_DATA=false` and provide Supabase credentials for real data.
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Production | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Production | Supabase anonymous key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Admin ops | Supabase service role key (server-side only) |
+| `NEXT_PUBLIC_DEFAULT_COUNTRY` | No | Default country code (`CO`, `EC`, `GT`). Default: `CO` |
+| `NEXT_PUBLIC_APP_URL` | No | App URL. Default: `http://localhost:3000` |
+| `NEXT_PUBLIC_ENABLE_MOCK_DATA` | No | Enable mock data mode. Default: `true` |
+| `NEXT_PUBLIC_ENABLE_OFFLINE_MODE` | No | Enable offline/PWA mode. Default: `true` |
+| `NEXT_PUBLIC_ENABLE_BIOMETRIC_AUTH` | No | Enable biometric auth. Default: `false` |
+
+## Scripts
+
+```bash
+npm run dev              # Development server (port 3000)
+npm run build            # Production build
+npm run start            # Start production server
+npm run lint             # ESLint
+npm run test:e2e         # Playwright E2E tests (all 3 browser projects)
+npm run test:e2e:ui      # Playwright with interactive UI
+npm run test:e2e:headed  # Playwright with visible browser
+```
+
+## Tests
+
+- **Framework:** Playwright
+- **Location:** `tests/e2e/`
+- **Projects:** chromium-desktop, mobile-chrome (Pixel 5), mobile-safari (iPhone 12)
+- **Config:** `playwright.config.ts`
+- **Run all:** `npm run test:e2e`
+- **Run specific:** `npx playwright test tests/e2e/auth/`
+- **Report:** `npx playwright show-report`
+- Tests run against `http://localhost:3000` with auto-start dev server.
+- Tests use mock data -- no Supabase connection required.
+
+## Deployment
+
+- **Platform:** Vercel (recommended)
+- **CI:** GitHub Actions (`.github/workflows/ci.yml`) runs build, lint, and Playwright tests on push/PR to main.
+- **Branch:** `main` is the production branch.
+
+## Project-Specific Rules
+
+### Language in Code vs UI
+
+- All citizen-facing UI text MUST be in Spanish (labels, buttons, messages, placeholders, ARIA labels, error messages).
+- All code (variable names, comments, function names, type names) MUST be in English.
+- Documentation exists in both English (`docs/en/`) and Spanish (`docs/es/`).
+
+### Component Conventions
+
+- Use `'use client'` directive only when the component uses hooks or state.
+- Use the `cn()` utility from `@/lib/utils/cn` for conditional TailwindCSS classes.
+- Use `@/` path alias for imports (maps to `src/`).
+- Mobile-first responsive design. Always test on mobile viewports.
+- Dark mode support via `dark:` prefix on all visual components.
+
+### Mock Data
+
+- Mock data files are in `src/lib/mock/` and follow the same TypeScript types as the database schema.
+- The app automatically falls back to mock data when Supabase credentials are not configured.
+- Keep mock data as a fallback behind `NEXT_PUBLIC_ENABLE_MOCK_DATA` flag -- do not remove it.
+
+### Multi-Country
+
+- Country configuration files are in `src/config/countries/`. Each country is a single JSON file.
+- Use `useCountry()` hook from `@/lib/contexts/CountryContext` to access country-specific data.
+- In production, each deployment is fixed to a single country. The `CountrySwitcher` is for admin/demo mode only.
+
+### Database and Security
+
+- All database tables have Row-Level Security (RLS) enabled. RLS policies use `auth.uid()` to enforce data isolation.
+- Never reference `auth.users` table from RLS policies -- regular users cannot query it. Use `auth.jwt()` only.
+- Citizen routes are protected by `auth-token` cookie. Agency routes use a separate `agency-token` cookie.
+- API routes skip middleware auth checks and validate tokens server-side.
+- The `SUPABASE_SERVICE_ROLE_KEY` must NEVER be exposed to the client.
+
+### Test Conventions
+
+- Test files use `.spec.ts` extension.
+- Tests are organized by feature area under `tests/e2e/`.
+- Use `data-testid` attributes for reliable element selection.
+- Citizen UI assertions use Spanish text (e.g., `getByText('Panel Principal')`).
+- Each test should work in isolation -- do not depend on test execution order.
+- Test against both desktop and mobile viewports.
+
+### Commits and Changelog
+
+- Follow Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`).
+- Update `CHANGELOG.md` following Keep a Changelog format for user-facing changes.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,251 @@
+# Onboarding Guide -- Mi Colombia Digital
+
+Welcome to Mi Colombia Digital, a Citizen Digital Wallet platform for Colombia. This guide will get you up and running as a new developer on the team.
+
+> Detailed onboarding documentation is also available in [English](docs/en/ONBOARDING.md) and [Spanish](docs/es/ONBOARDING.md).
+
+---
+
+## 1. Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Node.js | 18+ (20 LTS recommended) | JavaScript runtime |
+| npm | 9+ | Package manager |
+| Git | Latest | Version control |
+| VS Code | Latest (recommended) | Code editor |
+| Supabase CLI | Latest (optional) | Database management |
+
+### Recommended VS Code Extensions
+
+- ESLint
+- Tailwind CSS IntelliSense
+- TypeScript Importer
+- Prettier
+- ES7+ React Snippets
+
+---
+
+## 2. First-Time Setup
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/digar011/colombia-digital-wallet.git
+cd colombia-digital-wallet
+
+# 2. Install dependencies
+npm install
+
+# 3. Set up environment variables
+cp .env.local.example .env.local
+# Edit .env.local with your Supabase credentials, or leave defaults for mock mode
+
+# 4. Install Playwright browsers (for testing)
+npx playwright install
+
+# 5. Start the development server
+npm run dev
+
+# 6. Open http://localhost:3000 in your browser
+```
+
+### Demo Mode
+
+The app runs fully in mock mode without any Supabase connection. Mock data loads automatically when no backend is configured.
+
+**Demo credentials:**
+- Email: `demo@micolombiadigital.gov.co`
+- Password: `demo123`
+
+**Test admin credentials:**
+- Email: `admin123@test.gov.co`
+- Password: `Test123!`
+
+---
+
+## 3. Architecture Overview
+
+### Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | Next.js 14 (App Router), TypeScript, TailwindCSS |
+| State | Zustand (global), TanStack React Query (server) |
+| Backend | Supabase (PostgreSQL, Auth, Storage, Real-time) |
+| PWA | next-pwa (offline support, installable) |
+| Testing | Playwright (E2E) |
+| CI/CD | GitHub Actions |
+| Deployment | Vercel (recommended) |
+
+### Route Groups
+
+The app uses Next.js App Router route groups to separate layouts:
+
+| Group | Purpose | Layout |
+|-------|---------|--------|
+| `(auth)/` | Login, Register, Verify | Minimal layout |
+| `(citizen)/` | Citizen-facing app (Spanish UI) | Header + BottomNav |
+| `(admin)/` | Government admin dashboard | Sidebar + AdminHeader |
+| `(agency)/` | Agency staff portal | AgencySidebar + AgencyHeader |
+
+### Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/app/` | Pages and API routes (Next.js App Router) |
+| `src/components/ui/` | Reusable UI components (Button, Card, Input, etc.) |
+| `src/components/documents/` | Document card components (Cedula, Vehicle, Health) |
+| `src/components/layout/` | Layout components (BottomNav, Header, Sidebar, AgencySidebar) |
+| `src/config/countries/` | Country-specific JSON configurations (CO, EC, GT) |
+| `src/lib/contexts/` | React contexts (Auth, Country, AdminRole) |
+| `src/lib/hooks/` | Custom React hooks (useAuth) |
+| `src/lib/mock/` | Mock data for development (citizenData, adminData, agencyData, ticketData) |
+| `src/lib/supabase/` | Supabase client configuration (client.ts, server.ts, middleware.ts) |
+| `src/lib/validations/` | Zod validation schemas (auth, citizen, admin) |
+| `src/lib/utils/` | Utility functions (cn.ts, logger.ts, csrf.ts) |
+| `src/lib/middleware/` | Rate limiter middleware |
+| `supabase/migrations/` | SQL database migrations |
+| `tests/e2e/` | Playwright E2E test files |
+| `docs/en/` | English documentation |
+| `docs/es/` | Spanish documentation |
+
+---
+
+## 4. Key Architecture Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| PWA over Native App | PWA | Faster iteration, no app store dependency, Playwright testing |
+| Next.js App Router | App Router | Server components, route groups for layout separation |
+| Supabase over Custom API | Supabase | Built-in auth, RLS, real-time, fast setup |
+| TailwindCSS over CSS-in-JS | TailwindCSS | Performance, consistency, easy theming |
+| Zustand over Redux | Zustand | Simpler, less boilerplate, sufficient for needs |
+| Mock-first development | Yes | Full UI functional without backend for demos and stakeholder review |
+| Spanish-first citizen UI | Yes | Colombian users are native Spanish speakers |
+| White-label config per country | JSON files | Single config per country enables rapid multi-country expansion |
+
+---
+
+## 5. Conventions
+
+### Language
+
+- **Citizen-facing UI**: All text in Spanish (labels, buttons, messages, placeholders)
+- **Code**: English (variable names, comments, function names)
+- **Documentation**: Separate English (`docs/en/`) and Spanish (`docs/es/`) versions
+
+### File Naming
+
+| Type | Convention | Example |
+|------|-----------|---------|
+| Components | PascalCase.tsx | `DocumentCard.tsx` |
+| Pages | page.tsx | Next.js convention |
+| Hooks | useXxx.ts | `useAuth.ts` |
+| Contexts | XxxContext.tsx | `AuthContext.tsx` |
+| Utils | camelCase.ts | `formatDate.ts` |
+| Types | camelCase.ts | `database.ts` |
+| Tests | xxx.spec.ts | `auth.spec.ts` |
+
+### Styling
+
+- Use TailwindCSS for all styling
+- Use `cn()` utility from `@/lib/utils/cn` for conditional classes
+- Mobile-first responsive design (`sm:`, `md:`, `lg:` breakpoints)
+- Dark mode support via `dark:` prefix
+- Use country config colors for branding
+
+### Git Workflow
+
+```
+main          -- production-ready code
+  feature/xxx -- new features
+  fix/xxx     -- bug fixes
+  docs/xxx    -- documentation updates
+```
+
+---
+
+## 6. Multi-Country System
+
+Each country has a JSON config file in `src/config/countries/`:
+- `colombia.json` -- Colors, documents, agencies, emergency numbers, social programs
+- `ecuador.json` -- Ecuador-specific configuration
+- `guatemala.json` -- Guatemala-specific configuration
+
+To add a new country:
+1. Create `src/config/countries/[country-code].json`
+2. Register it in `src/config/index.ts`
+3. Add country flag to `public/flags/`
+4. Test with the `CountrySwitcher` component
+
+---
+
+## 7. Database
+
+### Migrations
+
+SQL migration files are in `supabase/migrations/`:
+- `001_initial_schema.sql` -- 12 tables and indexes
+- `002_rls_policies.sql` -- Row Level Security policies for all tables
+
+### Key Tables
+
+`citizens`, `digital_documents`, `vehicles`, `health_records`, `vaccinations`, `family_members`, `citizen_services`, `work_tax_records`, `appointments`, `verification_logs`, `admin_users`, `notifications`
+
+All tables have Row-Level Security (RLS) enabled.
+
+---
+
+## 8. Testing
+
+```bash
+npm run test:e2e              # Run all E2E tests
+npm run test:e2e:ui           # Run with Playwright UI mode
+npm run test:e2e:headed       # Run with visible browser
+npx playwright test tests/e2e/auth/      # Run specific suite
+npx playwright show-report    # View HTML report
+```
+
+Tests run on 3 Playwright projects: chromium-desktop, mobile-chrome (Pixel 5), mobile-safari (iPhone 12).
+
+---
+
+## 9. Common Tasks
+
+### Add a new document type
+
+1. Add type to `src/config/countries/colombia.json` under `documents`
+2. Add TypeScript type in `src/lib/types/database.ts`
+3. Create card component in `src/components/documents/`
+4. Add page in `src/app/(citizen)/documents/`
+5. Add mock data in `src/lib/mock/citizenData.ts`
+6. Write Playwright test in `tests/e2e/citizen/`
+
+### Modify the database schema
+
+1. Create new migration file in `supabase/migrations/`
+2. Update TypeScript types in `src/lib/types/database.ts`
+3. Update mock data if needed
+4. Run `npx supabase db push`
+
+---
+
+## 10. Troubleshooting
+
+**"Module not found" errors** -- Run `npm install` to reinstall dependencies.
+
+**Port 3000 already in use** -- Kill the process (`npx kill-port 3000`) or use a different port (`npm run dev -- -p 3001`).
+
+**Supabase connection failing** -- Check `.env.local` has correct values. The app automatically falls back to mock data when no backend is configured.
+
+**Playwright tests failing** -- Run `npx playwright install` to install/update browsers, then `npm run build` to verify the production build works.
+
+---
+
+## Need Help?
+
+- Check the [English docs](docs/en/) or [Spanish docs](docs/es/)
+- Review `docs/PRODUCTION_ROADMAP.md` for full change history and rationale
+- Review `docs/TODO_QUEUE.md` for the current backlog
+- Contact Diego Garnica: diego.j.garnica@gmail.com
+- Open an issue on GitHub

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,173 @@
+# Product Overview -- Mi Colombia Digital
+
+## Vision
+
+Mi Colombia Digital is a Citizen Digital Wallet platform that centralizes government documents and services into a single Progressive Web App (PWA). Modeled after Argentina's successful miArgentina platform (21M+ users), it is adapted for Colombia's government systems and designed as a white-label, multi-country framework.
+
+Instead of carrying multiple physical documents and visiting different government offices, Colombian citizens access everything from their smartphone -- even offline.
+
+---
+
+## Target Users
+
+| User Type | Description | Primary Actions |
+|-----------|-------------|-----------------|
+| **Citizens** | Colombian citizens (21M+ potential users) | View digital ID, vehicle registration, health cards; present QR codes for verification |
+| **Government Officials** | Field officers, police, inspectors | Scan citizen QR codes to verify document authenticity |
+| **Agency Staff** | Government agency employees across 6 agencies | Manage documents, look up citizens, handle verification requests |
+| **Admin Operators** | Platform administrators | Issue documents, manage citizen accounts, view analytics, configure system |
+
+---
+
+## Features
+
+### Citizen Modules
+
+| Module | Route | Description |
+|--------|-------|-------------|
+| **Cedula Digital** | `/documents/identity` | View, share, and verify Cedula de Ciudadania digitally. Displays Tarjeta de Identidad for minors (under 18). |
+| **Vehiculos (RUNT)** | `/documents/vehicles` | Vehicle registration, SOAT (mandatory insurance), technomechanical certificates. Integrates with RUNT data model. |
+| **Salud (EPS/ADRES)** | `/documents/health` | EPS affiliation card, vaccination records, SISBEN score, chronic condition alerts. |
+| **Trabajo y Tributario (DIAN)** | `/documents/work` | RUT (tax ID), employment certificates, pension fund, ARL, cesantias information. |
+| **Familia** | `/documents/family` | Linked family members, children's Tarjeta de Identidad, guardianship records. |
+| **Programas Sociales** | `/services` | SISBEN, Familias en Accion, Ingreso Solidario, Colombia Mayor enrollment status. Appointment booking at `/services/book`. |
+| **Emergencias** | `/emergency` | One-tap calling for 123, police, fire, ambulance with country-specific emergency numbers. |
+| **Perfil** | `/profile` | Citizen profile management, notification preferences, account settings. |
+
+### QR Code Verification
+
+Documents include scannable QR codes with digital signatures. Government officials scan the QR to verify authenticity in real time. QR codes are pre-generated and valid for 24 hours, enabling offline verification.
+
+### Offline Mode (PWA)
+
+Core documents are cached locally for offline viewing. Citizens in areas with poor connectivity can still present their Cedula, health card, and vehicle registration without an internet connection. The app is installable as a PWA via "Add to Home Screen."
+
+### Government Admin Dashboard
+
+| Page | Route | Capabilities |
+|------|-------|-------------|
+| Dashboard | `/admin/dashboard` | Platform metrics: registered citizens, documents issued, verification activity, system health |
+| Users | `/admin/users` | Search, view, and manage citizen accounts. Detail view at `/admin/users/[id]` |
+| Documents | `/admin/documents` | Issue, review, suspend, and revoke digital documents |
+| Analytics | `/admin/analytics` | Registration trends, verification volumes, geographic distribution, program enrollment |
+| Tickets | `/admin/tickets` | Support ticket system for citizen inquiries |
+| Settings | `/admin/settings` | Platform configuration, notification rules, admin access management |
+
+### Agency Portal
+
+The Agency Portal (`/agency`) provides a dedicated interface for government agency staff. It supports 3 countries with 6 agencies per country.
+
+**Supported Countries and Agencies:**
+
+| Country | Identity | Vehicles | Tax | Health | Social Services | Technology |
+|---------|----------|----------|-----|--------|-----------------|------------|
+| Colombia | RNEC | RUNT | DIAN | ADRES | DPS | MinTIC |
+| Ecuador | Registro Civil | ANT | SRI | IESS | MIES | MINTEL |
+| Guatemala | RENAP | SAT-Vehiculos | SAT | IGSS | MIDES | CIV |
+
+**Agency Keys:** `identity`, `vehicles`, `tax`, `health`, `socialServices`, `technology`
+
+**Agency Features:**
+- Institutional login (`.gov.co` email credentials)
+- Sidebar dropdown to switch between agencies
+- Document management (issue, revoke documents for the agency's domain)
+- Citizen lookup (search by cedula number, name, or other identifiers)
+- Verification request queue (approve/reject pending requests)
+- Agency-specific analytics dashboard
+- Agency configuration settings
+
+---
+
+## Multi-Country Support
+
+The platform is designed as a white-label framework. Each country deployment is configured via a single JSON file in `src/config/countries/`:
+
+| Config Area | Examples |
+|-------------|----------|
+| Colors | National flag colors for branding |
+| Documents | Document types, formats, issuing authorities |
+| Agencies | Government agencies with names and descriptions |
+| Emergency Numbers | Country-specific emergency contacts |
+| Social Programs | Available government programs |
+| Health System | Healthcare system structure |
+
+Currently configured: **Colombia** (primary), **Ecuador** (proof-of-concept), **Guatemala** (proof-of-concept).
+
+---
+
+## API Surface (Planned)
+
+> **Status:** API routes are planned and documented but not yet implemented. The app currently uses client-side mock data and direct Supabase client calls.
+
+See `docs/en/API_REFERENCE.md` for the full planned API contract.
+
+| Group | Endpoints | Auth Required |
+|-------|-----------|---------------|
+| Auth | `POST /api/auth/login`, `register`, `logout`, `refresh` | No (login/register) |
+| Citizens | `GET/PATCH /api/citizens/me` | Yes (citizen JWT) |
+| Documents | `GET /api/documents`, `GET /api/documents/:id`, `GET /api/documents/:id/qr` | Yes (citizen JWT) |
+| Vehicles | `GET /api/vehicles`, `GET /api/vehicles/:id` | Yes (citizen JWT) |
+| Health | `GET /api/health`, `GET /api/health/vaccinations` | Yes (citizen JWT) |
+| Services | `GET /api/services`, `GET/POST /api/appointments` | Yes (citizen JWT) |
+| Verification | `POST /api/verify` | No (public) |
+| Admin | `GET /api/admin/citizens`, `GET /api/admin/citizens/:id`, `POST /api/admin/documents/issue`, `GET /api/admin/analytics`, `GET /api/admin/verification-logs` | Yes (admin JWT) |
+
+---
+
+## Database Schema
+
+12 PostgreSQL tables managed via Supabase with Row-Level Security (RLS) on all tables:
+
+| Table | Description |
+|-------|------------|
+| `citizens` | Core citizen profiles (extends auth.users) |
+| `digital_documents` | Digital document records with QR data and signatures |
+| `vehicles` | Vehicle registration (RUNT) |
+| `health_records` | EPS affiliation, SISBEN |
+| `vaccinations` | Vaccination records with dose tracking |
+| `family_members` | Linked family relationships |
+| `citizen_services` | Social program enrollments |
+| `work_tax_records` | RUT, employment, pension info |
+| `appointments` | Government service appointments |
+| `verification_logs` | QR scan verification audit trail |
+| `admin_users` | Government admin accounts with role-based permissions |
+| `notifications` | Citizen notification system |
+
+---
+
+## Security
+
+- **Row-Level Security (RLS):** All database tables enforce citizen data isolation at the PostgreSQL level using `auth.uid()`
+- **Security Headers:** CSP, HSTS (2-year max-age with preload), X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy
+- **Zod Validation:** Input validation schemas with Spanish error messages for citizen-facing forms
+- **CSRF Protection:** Double-submit cookie pattern with constant-time token comparison (ready for API integration)
+- **Rate Limiting:** In-memory sliding-window rate limiter with 4 tiers (auth, citizen, verification, admin)
+- **Structured Logging:** JSON logging with audit trail functions for API requests, auth events, and document access
+
+---
+
+## Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| First Contentful Paint | < 1.5s |
+| Largest Contentful Paint | < 2.5s |
+| Time to Interactive | < 3s |
+| Cumulative Layout Shift | < 0.1 |
+| Offline Document Load | < 500ms |
+| QR Code Generation | < 200ms |
+
+---
+
+## Current Status
+
+The platform is in active development. The citizen UI, admin dashboard, and agency portal are fully functional with mock data. Production-critical work remaining includes:
+
+1. Replace mock authentication with Supabase Auth
+2. Implement API routes (server-side data access)
+3. Connect all pages to real database queries
+4. End-to-end RLS verification with real auth tokens
+5. Service worker implementation for true offline support
+
+See `docs/PRODUCTION_ROADMAP.md` for the complete change history and planned phases.
+See `docs/TODO_QUEUE.md` for the prioritized backlog.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,94 @@
+# TODO -- Mi Colombia Digital
+
+> Task queue for the Mi Colombia Digital platform.
+> For detailed descriptions, dependencies, and file-level instructions, see `docs/TODO_QUEUE.md`.
+> For full rationale behind each change, see `docs/PRODUCTION_ROADMAP.md`.
+>
+> Last Updated: 2026-02-28
+
+---
+
+## Queue
+
+### P0 -- Blockers
+
+- [ ] Replace mock auth with Supabase Auth (useAuth, AuthContext, middleware, login/register/verify pages)
+- [ ] Implement API routes for all endpoints documented in `docs/en/API_REFERENCE.md`
+- [ ] Connect all citizen/admin/agency pages to real data via TanStack React Query hooks
+
+### P1 -- Critical
+
+- [ ] End-to-end RLS verification with real Supabase Auth tokens across all 12 tables
+- [ ] Wire Zod validation schemas into all API routes (server-side) and form components (client-side)
+- [ ] Integrate CSRF protection into state-changing API routes
+- [ ] Set up Sentry error monitoring (`@sentry/nextjs`)
+- [ ] Implement structured server-side logging in API routes (audit trail for document access)
+
+### P2 -- High
+
+- [ ] Generate production PWA icons (replace placeholder SVGs with proper app logo assets)
+- [ ] Implement service worker with `next-pwa` for offline document caching
+- [ ] Expand E2E test coverage (admin flows, error states, accessibility tests with axe)
+- [ ] WCAG 2.1 AA accessibility audit (Lighthouse, screen reader testing, keyboard navigation)
+
+### P3 -- Medium
+
+- [ ] Rate limiting on auth and verification endpoints (apply `src/lib/middleware/rateLimit.ts` to API routes)
+- [ ] Performance optimization (Lighthouse audit, bundle analysis, image optimization)
+- [ ] Load testing with k6 or Artillery (target: 10,000 concurrent users)
+- [ ] API key management for external agency integrations
+
+---
+
+## In Progress
+
+(none currently)
+
+---
+
+## Completed
+
+### Standardization (2026-02-28)
+- [x] Create `ONBOARDING.md` at project root
+- [x] Create `PRODUCT.md` with product overview and feature specs
+- [x] Create `TODO.md` with task queue
+- [x] Create `.env.example` with all required environment variables
+- [x] Create `CLAUDE.md` with project-level standards
+
+### Documentation and Security Audit (2026-02-26)
+- [x] Update all 8 documentation files (4 English + 4 Spanish) to match codebase
+- [x] Add security headers in `next.config.mjs` (CSP, HSTS, X-Frame-Options, etc.)
+- [x] Set up GitHub Actions CI/CD pipeline (`.github/workflows/ci.yml`)
+- [x] Create `CHANGELOG.md` with full project history
+- [x] Create `docs/PRODUCTION_ROADMAP.md` with completed and planned phases
+- [x] Create `docs/TODO_QUEUE.md` with prioritized backlog
+- [x] Add Zod validation schemas (`src/lib/validations/`)
+- [x] Add logger utility (`src/lib/utils/logger.ts`)
+- [x] Add rate limiter (`src/lib/middleware/rateLimit.ts`)
+- [x] Add CSRF protection utility (`src/lib/utils/csrf.ts`)
+- [x] Add PWA icon SVGs (`public/icons/`)
+- [x] Add country flag SVGs (`public/flags/`)
+- [x] Add skeleton loading components and loading states
+- [x] Add accessibility improvements (skip-to-content, focus trapping, ARIA labels)
+- [x] Add 78 new E2E tests (admin users, admin documents, admin analytics, citizen identity, citizen vehicles, citizen health, mobile navigation)
+
+### Agency Portal (2026-02-23)
+- [x] Build complete agency portal with 6 agencies per country across 3 countries
+- [x] Agency login with institutional `.gov.co` email auth
+- [x] AgencySidebar and AgencyHeader layout components
+- [x] Translate all admin pages to Spanish (305+ strings)
+- [x] Add age-based identity documents (Tarjeta de Identidad for minors)
+- [x] PWA `manifest.json`
+- [x] 9 agency E2E tests
+
+### Core Platform (2026-02-22)
+- [x] Next.js 14 project scaffolding with TypeScript, TailwindCSS, ESLint
+- [x] 8 citizen modules (Identity, Vehicles, Health, Work, Family, Services, Emergency, Profile)
+- [x] Government admin dashboard (users, documents, analytics, tickets, settings)
+- [x] Authentication flows (login, register, verify) with mock auth
+- [x] 11 reusable UI components + document/card/layout components
+- [x] Multi-country configuration (Colombia, Ecuador, Guatemala)
+- [x] Supabase integration (client, server, middleware)
+- [x] Database schema (12 tables) with RLS policies
+- [x] Playwright E2E test suite
+- [x] Bilingual documentation (English + Spanish)


### PR DESCRIPTION
## Summary
- Added **ONBOARDING.md** — root-level developer guide linking to detailed bilingual docs in docs/en/ and docs/es/
- Added **PRODUCT.md** — product overview (citizen modules, QR verification, offline mode, admin dashboard, agency portal for 3 countries x 6 agencies, multi-country support, security, performance targets)
- Added **TODO.md** — task queue (P0-P3 priority items + completed historical work across 4 phases)
- Added **.env.example** — consolidated 8-variable reference grouped by category
- Added **CLAUDE.md** — project-level standards (stack, structure, conventions, mock data strategy, multi-country system, test conventions)

## Context
Standardizing all Codexium repositories to meet mandatory documentation requirements per global CLAUDE.md. Existing README.md, CHANGELOG.md, and .env.local.example were already adequate — left untouched.

## Checklist
- [x] Only documentation files added (no source code changes)
- [x] All 5 required files present and accurate
- [x] Commit follows Conventional Commits format

## Test plan
- [ ] All markdown files render correctly on GitHub
- [ ] No source code was modified
- [ ] Documentation is accurate to current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)